### PR TITLE
cambio de nombres de atributos

### DIFF
--- a/dile-simple-select.html
+++ b/dile-simple-select.html
@@ -24,9 +24,9 @@
       }
     </style>
     <div>
-      <label for="theselect">[[datalabel]]</label>
+      <label for="theselect">[[customLabel]]</label>
       <select value="{{seldata::change}}" id="theselect" class$="[[selclass]]">
-        <template is="dom-repeat" items="{{dataArray}}">
+        <template is="dom-repeat" items="{{customData}}">
           <template is="dom-if" if="{{selecdata(index)}}">
             <option value="[[item]]" selected>[[item]]</option>
           </template>
@@ -76,13 +76,13 @@
            *
            * @type {Array}
            */
-          dataArray: Array,
+          customData: Array,
           /**
            * The label show on the left of the component
            *
            * @type {String}
            */
-          datalabel: String,
+          customLabel: String,
           /**
            * The value used to detect an invalid value
            *
@@ -103,7 +103,7 @@
         *
         */
       selecdata(index) {
-        if (this.seldata == this.dataArray[index])
+        if (this.seldata == this.customData[index])
           return true;
         return false;
       }

--- a/dile-time-select.html
+++ b/dile-time-select.html
@@ -24,23 +24,23 @@
     </style>
     <div>
       <dile-simple-select 
-        datalabel='[[hourlabel]]' 
-        data-array='[[hourArray]]' 
+        custom-label='[[hourlabel]]' 
+        custom-data='[[hourArray]]' 
         on-dataselected="hourChange"
         nullvalue="[[nullvalue]]"
         seldata="[[hour]]"
       ></dile-simple-select>
       <dile-simple-select 
-        datalabel='[[minutelabel]]' 
-        data-array='[[minuteArray]]' 
+        custom-label='[[minutelabel]]' 
+        custom-data='[[minuteArray]]' 
         on-dataselected="minuteChange"
         nullvalue="[[nullvalue]]"
         seldata="[[minute]]"
       ></dile-simple-select>
       <template is="dom-if" if="[[shortMode]]">
         <dile-simple-select
-          datalabel='[[ampmlabel]]'
-          data-array="[[ampmArray]]"
+          custom-label='[[ampmlabel]]'
+          custom-data="[[ampmArray]]"
           on-dataselected="ampmChange"
           nullvalue="[[nullvalue]]"
           seldata="[[ampm]]"


### PR DESCRIPTION
He cambiado nombres de atributos usados en el dile-simple-select

- dataArray
- datalabel

Estos atributos podrían confundirse con "data attributes" del html5. 
Por consistencia, he colocado datalabel con un formato de camelcase.

Ahora los atributos se llaman:

- custom-label
- custom-data
